### PR TITLE
Bugfix: Handle fail in simulation.wait_for_results

### DIFF
--- a/securicad/enterprise/simulations.py
+++ b/securicad/enterprise/simulations.py
@@ -57,7 +57,7 @@ class Simulation:
             return
         while True:
             self.__update_progress()
-            if self.progress == 100:
+            if self.progress < 0 or self.progress == 100:  # failed or finished
                 break
             time.sleep(1)
 


### PR DESCRIPTION
We didn't handle the case of bad model or similar.